### PR TITLE
Fix `expected table, got nil` issue.

### DIFF
--- a/wpp.lua
+++ b/wpp.lua
@@ -383,7 +383,7 @@ end
 
 function remotePeripheral.find(type, filterFunction)
     log("New find(".. type ..", hasFilterFunction=".. tostring(not(not filterFunction) or false) ..")")
-    local foundToReturn = nativePeripheral.find(type, filterFunction)
+    local foundToReturn = {nativePeripheral.find(type, filterFunction)}
 
     local allPeripherals = remotePeripheral.getNames()
 


### PR DESCRIPTION
If the native peripheral methods return nothing, then no table is created, thus when an attempt is made to do `table.insert(foundToReturn, ...)` it fails, as `foundToReturn` is `nil`.

`peripheral.find` doesn't return a table of peripherals, rather it returns a tuple of peripherals. Because of this, you need to wrap the call in your own table, otherwise you are just grabbing the first peripheral (or nothing, if no peripheral is found).