### PR TITLE
Fix return type on find()

### DIFF
--- a/wpp.lua
+++ b/wpp.lua
@@ -388,8 +388,8 @@ function remotePeripheral.find(_type, filterFunction)
     local allPeripherals = remotePeripheral.getNames()
 
     for n,peripheralUrl in ipairs(allPeripherals) do
+        print(remotePeripheral.getType(peripheralUrl))
         if remotePeripheral.getType(peripheralUrl) == _type then
-            print(remotePeripheral.getType(peripheralUrl))
             local wrappedPeripheral = remotePeripheral.wrap(peripheralUrl)
 
             if filterFunction then

--- a/wpp.lua
+++ b/wpp.lua
@@ -381,14 +381,14 @@ function remotePeripheral.wrap(peripheralUrl)
     end
 end
 
-function remotePeripheral.find(type, filterFunction)
-    log("New find(".. type ..", hasFilterFunction=".. tostring(not(not filterFunction) or false) ..")")
-    local foundToReturn = {nativePeripheral.find(type, filterFunction)}
+function remotePeripheral.find(_type, filterFunction)
+    log("New find(".. _type ..", hasFilterFunction=".. tostring(not(not filterFunction) or false) ..")")
+    local foundToReturn = {nativePeripheral.find(_type, filterFunction)}
 
     local allPeripherals = remotePeripheral.getNames()
 
     for n,peripheralUrl in ipairs(allPeripherals) do
-        if remotePeripheral.getType(peripheralUrl) == type then
+        if remotePeripheral.getType(peripheralUrl) == _type then
             local wrappedPeripheral = remotePeripheral.wrap(peripheralUrl)
 
             if filterFunction then
@@ -403,11 +403,11 @@ function remotePeripheral.find(type, filterFunction)
         end
     end
 
-    local next = next
     if next(foundToReturn) == nil then
+        print("returning nil from find")
         return nil
     else
-        return foundToReturn
+        return table.unpack(foundToReturn)
     end
 end
 -- End->New peripheral API using WPP

--- a/wpp.lua
+++ b/wpp.lua
@@ -388,9 +388,7 @@ function remotePeripheral.find(_type, filterFunction)
     local allPeripherals = remotePeripheral.getNames()
 
     for n,peripheralUrl in ipairs(allPeripherals) do
-        print(remotePeripheral.getType(peripheralUrl))
         if remotePeripheral.getType(peripheralUrl) == _type then
-            print("matches type")
             local wrappedPeripheral = remotePeripheral.wrap(peripheralUrl)
 
             if filterFunction then
@@ -407,7 +405,6 @@ function remotePeripheral.find(_type, filterFunction)
 
     local next = next
     if next(foundToReturn) == nil then
-        print("returning nil from find")
         return nil
     else
         return table.unpack(foundToReturn)

--- a/wpp.lua
+++ b/wpp.lua
@@ -390,6 +390,7 @@ function remotePeripheral.find(_type, filterFunction)
     for n,peripheralUrl in ipairs(allPeripherals) do
         print(remotePeripheral.getType(peripheralUrl))
         if remotePeripheral.getType(peripheralUrl) == _type then
+            print("matches type")
             local wrappedPeripheral = remotePeripheral.wrap(peripheralUrl)
 
             if filterFunction then
@@ -404,6 +405,7 @@ function remotePeripheral.find(_type, filterFunction)
         end
     end
 
+    local next = next
     if next(foundToReturn) == nil then
         print("returning nil from find")
         return nil

--- a/wpp.lua
+++ b/wpp.lua
@@ -389,6 +389,7 @@ function remotePeripheral.find(_type, filterFunction)
 
     for n,peripheralUrl in ipairs(allPeripherals) do
         if remotePeripheral.getType(peripheralUrl) == _type then
+            print(remotePeripheral.getType(peripheralUrl))
             local wrappedPeripheral = remotePeripheral.wrap(peripheralUrl)
 
             if filterFunction then


### PR DESCRIPTION
`nativePeripheral.find()` returns multiple values so it needs to be wrapped in a table. Then we can add the found remote peripheral to that table. When we return from find() we have to unpack the table.